### PR TITLE
update fork

### DIFF
--- a/src/esphome/application.cpp
+++ b/src/esphome/application.cpp
@@ -1193,6 +1193,12 @@ io::MCP23017 *Application::make_mcp23017_component(uint8_t address) {
 }
 #endif
 
+#ifdef USE_SDS011
+sensor::SDS011Component *Application::make_sds011(UARTComponent *parent) {
+  return this->register_component(new SDS011Component(parent));
+}
+#endif
+
 Application App;  // NOLINT
 
 ESPHOME_NAMESPACE_END

--- a/src/esphome/application.h
+++ b/src/esphome/application.h
@@ -126,6 +126,7 @@
 #include "esphome/sensor/ultrasonic_sensor.h"
 #include "esphome/sensor/uptime_sensor.h"
 #include "esphome/sensor/wifi_signal_sensor.h"
+#include "esphome/sensor/sds011_component.h"
 #include "esphome/stepper/a4988.h"
 #include "esphome/stepper/stepper.h"
 #include "esphome/stepper/uln2003.h"
@@ -819,6 +820,10 @@ class Application {
 
 #ifdef USE_CUSTOM_SENSOR
   sensor::CustomSensorConstructor *make_custom_sensor(const std::function<std::vector<sensor::Sensor *>()> &init);
+#endif
+
+#ifdef USE_SDS011
+  sensor::SDS011Component *make_sds011(UARTComponent *parent);
 #endif
 
   /*    ___  _   _ _____ ____  _   _ _____

--- a/src/esphome/defines.h
+++ b/src/esphome/defines.h
@@ -59,6 +59,7 @@
 #define USE_PCF8574
 #define USE_MCP23017
 #define USE_IO
+#define USE_SDS011
 #define USE_MPU6050
 #define USE_TSL2561
 #define USE_BH1750

--- a/src/esphome/sensor/sds011_component.cpp
+++ b/src/esphome/sensor/sds011_component.cpp
@@ -1,0 +1,198 @@
+// Based on:
+//   - https://cdn.sparkfun.com/assets/parts/1/2/2/7/5/Laser_Dust_Sensor_Control_Protocol_V1.3.pdf
+
+#include "esphome/defines.h"
+
+#ifdef USE_SDS011
+
+#include "esphome/log.h"
+#include "esphome/sensor/sds011_component.h"
+
+ESPHOME_NAMESPACE_BEGIN
+
+namespace sensor {
+
+static const char *TAG = "sensor.sds011";
+static const uint8_t SDS011_MSG_REQUEST_LENGTH = 19;
+static const uint8_t SDS011_MSG_RESPONSE_LENGTH = 10;
+static const uint8_t SDS011_DATA_REQUEST_LENGTH = 15;
+static const uint8_t SDS011_DATA_RESPONSE_LENGTH = 6;
+static const uint8_t SDS011_MSG_HEAD = 0xaa;
+static const uint8_t SDS011_MSG_TAIL = 0xab;
+static const uint8_t SDS011_COMMAND_ID_REQUEST = 0xb4;
+static const uint8_t SDS011_COMMAND_ID_RESPONSE = 0xc5;
+static const uint8_t SDS011_COMMAND_ID_DATA = 0xc0;
+static const uint8_t SDS011_COMMAND_REPORT_MODE = 0x02;
+static const uint8_t SDS011_COMMAND_QUERY_DATA = 0x04;
+static const uint8_t SDS011_COMMAND_SET_DEVICE_ID = 0x05;
+static const uint8_t SDS011_COMMAND_SLEEP = 0x06;
+static const uint8_t SDS011_COMMAND_FIRMWARE = 0x07;
+static const uint8_t SDS011_COMMAND_PERIOD = 0x08;
+static const uint8_t SDS011_GET_MODE = 0x00;
+static const uint8_t SDS011_SET_MODE = 0x01;
+static const uint8_t SDS011_MODE_REPORT_ACTIVE = 0x00;
+static const uint8_t SDS011_MODE_REPORT_QUERY = 0x01;
+static const uint8_t SDS011_MODE_SLEEP = 0x00;
+static const uint8_t SDS011_MODE_WORK = 0x01;
+
+SDS011Component::SDS011Component(UARTComponent *parent, uint32_t update_interval_min, bool rx_mode_only)
+    : UARTDevice(parent), update_interval_min_(update_interval_min), rx_mode_only_(rx_mode_only) {}
+
+void SDS011Component::setup() {
+  if (this->rx_mode_only_) {
+    // In RX-only mode we do not setup the sensor, it is assumed to be setup
+    // already
+    return;
+  }
+  uint8_t command_data[SDS011_DATA_REQUEST_LENGTH] = {0};
+  command_data[0] = SDS011_COMMAND_REPORT_MODE;
+  command_data[1] = SDS011_SET_MODE;
+  command_data[2] = SDS011_MODE_REPORT_ACTIVE;
+  command_data[13] = 0xff;
+  command_data[14] = 0xff;
+  this->sds011_write_command_(command_data);
+
+  command_data[0] = SDS011_COMMAND_PERIOD;
+  command_data[1] = SDS011_SET_MODE;
+  command_data[2] = this->update_interval_min_;
+  command_data[13] = 0xff;
+  command_data[14] = 0xff;
+  this->sds011_write_command_(command_data);
+}
+
+void SDS011Component::dump_config() {
+  ESP_LOGCONFIG(TAG, "SDS011:");
+  ESP_LOGCONFIG(TAG, "  Update Interval: %u min", this->update_interval_min_);
+  ESP_LOGCONFIG(TAG, "  RX-only mode: %s", ONOFF(this->rx_mode_only_));
+  LOG_SENSOR("  ", "PM2.5", this->pm_2_5_sensor_);
+  LOG_SENSOR("  ", "PM10.0", this->pm_10_0_sensor_);
+}
+
+void SDS011Component::loop() {
+  const uint32_t now = millis();
+  if ((now - this->last_transmission_ >= 500) && this->data_index_) {
+    // last transmission too long ago. Reset RX index.
+    ESP_LOGV(TAG, "Last transmission too long ago. Reset RX index.");
+    this->data_index_ = 0;
+  }
+
+  if (this->available() == 0) {
+    return;
+  }
+
+  this->last_transmission_ = now;
+  while (this->available() != 0) {
+    this->read_byte(&this->data_[this->data_index_]);
+    auto check = this->check_byte_();
+    if (!check.has_value()) {
+      // finished
+      this->parse_data_();
+      this->data_index_ = 0;
+    } else if (!*check) {
+      // wrong data
+      ESP_LOGV(TAG, "Byte %i of received data frame is invalid.", this->data_index_);
+      this->data_index_ = 0;
+    } else {
+      // next byte
+      this->data_index_++;
+    }
+  }
+}
+
+SDS011Sensor *SDS011Component::make_pm_2_5_sensor(const std::string &name) {
+  return this->pm_2_5_sensor_ = new SDS011Sensor(name);
+}
+
+SDS011Sensor *SDS011Component::make_pm_10_0_sensor(const std::string &name) {
+  return this->pm_10_0_sensor_ = new SDS011Sensor(name);
+}
+
+float SDS011Component::get_setup_priority() const { return setup_priority::HARDWARE_LATE; }
+
+void SDS011Component::set_rx_mode_only(bool rx_mode_only) { this->rx_mode_only_ = rx_mode_only; }
+
+bool SDS011Component::get_rx_mode_only() const { return this->rx_mode_only_; }
+
+void SDS011Component::sds011_write_command_(const uint8_t *command_data) {
+  this->flush();
+  this->write_byte(SDS011_MSG_HEAD);
+  this->write_byte(SDS011_COMMAND_ID_REQUEST);
+  this->write_array(command_data, SDS011_DATA_REQUEST_LENGTH);
+  this->write_byte(sds011_checksum_(command_data, SDS011_DATA_REQUEST_LENGTH));
+  this->write_byte(SDS011_MSG_TAIL);
+}
+
+uint8_t SDS011Component::sds011_checksum_(const uint8_t *command_data, uint8_t length) const {
+  uint8_t sum = 0;
+  for (uint8_t i = 0; i < length; i++) {
+    sum += command_data[i];
+  }
+  return sum;
+}
+
+optional<bool> SDS011Component::check_byte_() const {
+  uint8_t index = this->data_index_;
+  uint8_t byte = this->data_[index];
+
+  if (index == 0) {
+    return byte == SDS011_MSG_HEAD;
+  }
+
+  if (index == 1) {
+    return byte == SDS011_COMMAND_ID_DATA;
+  }
+
+  if ((index >= 2) && (index <= 7)) {
+    return true;
+  }
+
+  if (index == 8) {
+    // checksum is without checksum bytes
+    uint8_t checksum = sds011_checksum_(this->data_ + 2, SDS011_DATA_RESPONSE_LENGTH);
+    if (checksum != byte) {
+      ESP_LOGW(TAG, "SDS011 Checksum doesn't match: 0x%02X!=0x%02X", byte, checksum);
+      return false;
+    }
+    return true;
+  }
+
+  if (index == 9) {
+    if (byte != SDS011_MSG_TAIL) {
+      return false;
+    }
+  }
+
+  return {};
+}
+
+void SDS011Component::parse_data_() {
+  this->status_clear_warning();
+  const float pm_2_5_concentration = this->get_16_bit_uint_(2) / 10.0f;
+  const float pm_10_0_concentration = this->get_16_bit_uint_(4) / 10.0f;
+
+  ESP_LOGD(TAG, "Got PM2.5 Concentration: %.1f µg/m³, PM10.0 Concentration: %.1f µg/m³", pm_2_5_concentration,
+           pm_10_0_concentration);
+  if (pm_2_5_concentration <= 0 && pm_10_0_concentration <= 0) {
+    // not yet any valid data
+    return;
+  }
+  if (this->pm_2_5_sensor_ != nullptr) {
+    this->pm_2_5_sensor_->publish_state(pm_2_5_concentration);
+  }
+  if (this->pm_10_0_sensor_ != nullptr) {
+    this->pm_10_0_sensor_->publish_state(pm_10_0_concentration);
+  }
+}
+
+uint16_t SDS011Component::get_16_bit_uint_(uint8_t start_index) const {
+  return (uint16_t(this->data_[start_index + 1]) << 8) | uint16_t(this->data_[start_index]);
+}
+void SDS011Component::set_update_interval_min(uint32_t update_interval_min) {
+  this->update_interval_min_ = update_interval_min;
+}
+
+}  // namespace sensor
+
+ESPHOME_NAMESPACE_END
+
+#endif  // USE_SDS011

--- a/src/esphome/sensor/sds011_component.h
+++ b/src/esphome/sensor/sds011_component.h
@@ -1,0 +1,68 @@
+#ifndef ESPHOME_SDS011_COMPONENT_H
+#define ESPHOME_SDS011_COMPONENT_H
+
+#include "esphome/defines.h"
+
+#ifdef USE_SDS011
+
+#include "esphome/component.h"
+#include "esphome/sensor/sensor.h"
+#include "esphome/uart_component.h"
+
+ESPHOME_NAMESPACE_BEGIN
+
+namespace sensor {
+
+using SDS011Sensor = sensor::EmptySensor<1, ICON_CHEMICAL_WEAPON, UNIT_MICROGRAMS_PER_CUBIC_METER>;
+
+class SDS011Component : public Component, public UARTDevice {
+ public:
+  /** Construct the component.
+   *
+   * @param parent UARTComponent
+   * @param update_interval_min The update interval in minutes.
+   * @param rx_mode_only RX-only mode to avoid sending data to the sensor.
+   */
+  SDS011Component(UARTComponent *parent, uint32_t update_interval_min = 0, bool rx_mode_only = false);
+
+  /// Manually set the rx-only mode. Defaults to false.
+  void set_rx_mode_only(bool rx_mode_only);
+
+  // ========== INTERNAL METHODS ==========
+  // (In most use cases you won't need these)
+  void setup() override;
+  void dump_config() override;
+  void loop() override;
+
+  float get_setup_priority() const override;
+  SDS011Sensor *make_pm_2_5_sensor(const std::string &name);
+  SDS011Sensor *make_pm_10_0_sensor(const std::string &name);
+  bool get_rx_mode_only() const;
+
+  void set_update_interval_min(uint32_t update_interval_min);
+
+ protected:
+  void sds011_write_command_(const uint8_t *command);
+  uint8_t sds011_checksum_(const uint8_t *command_data, uint8_t length) const;
+  optional<bool> check_byte_() const;
+  void parse_data_();
+  uint16_t get_16_bit_uint_(uint8_t start_index) const;
+
+  SDS011Sensor *pm_2_5_sensor_{nullptr};
+  SDS011Sensor *pm_10_0_sensor_{nullptr};
+
+  uint8_t data_[10];
+  uint8_t data_index_{0};
+  uint32_t last_transmission_{0};
+  uint32_t update_interval_min_;
+
+  bool rx_mode_only_;
+};
+
+}  // namespace sensor
+
+ESPHOME_NAMESPACE_END
+
+#endif  // USE_SDS011
+
+#endif  // ESPHOME_SDS011_COMPONENT_H

--- a/src/esphome/sensor/sensor.cpp
+++ b/src/esphome/sensor/sensor.cpp
@@ -158,7 +158,7 @@ const char UNIT_UT[] = "µT";
 const char UNIT_DEGREES[] = "°";
 const char UNIT_K[] = "K";
 const char UNIT_MICROSIEMENS_PER_CENTIMETER[] = "µS/cm";
-const char UNIT_MICROGRAMS_PER_CUBIC_METER[] = "µg/m^3";
+const char UNIT_MICROGRAMS_PER_CUBIC_METER[] = "µg/m³";
 const char ICON_CHEMICAL_WEAPON[] = "mdi:chemical-weapon";
 
 SensorStateTrigger::SensorStateTrigger(Sensor *parent) {


### PR DESCRIPTION
* Implement SDS011 sensor component

* Integrate SDS011

* use utf-8 symbol in units

* remove unnecessary defines

* imporve logging

* Fix merge

Messed that one up

* Run clang-format/clang-tidy

See https://github.com/esphome/esphome-core/pull/540

* do not cast update interval

* do not log the device id

* Move SDS011 outside of ESP32-only define

* better checking of float values

* remove query_mode

* Minor Changes

- Convert to PollingComponent (not strictly necessary, but if we decide to use update in the future this is better)
- Remove update_interval methods.
- Remove update_interval longer than 30min warning (takes up flash space and python already catches that)
- Lint line 50 (narrowing conversion from float to uint8_t)

* Re-add RX-only mode

The logic here got removed in the query_mode removal, re-adding it

* Use update interval in minutes

Not using PollingComponent was right. Also as the only way update interval is used here is minutes constrain the value to minutes.

## Description:


**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with python changes (if applicable):** esphome/esphome#<esphome PR number goes here>
**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Checklist:

  - [ ] The code change is tested and works locally.
  - [ ] The code change follows the [standards](https://esphome.io/guides/contributing.html#contributing-to-esphome-core)

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
