### PR TITLE
limit float to 2 decimal points

### DIFF
--- a/src/esphome/sensor/binary_sensor_map.cpp
+++ b/src/esphome/sensor/binary_sensor_map.cpp
@@ -50,7 +50,7 @@ void BinarySensorMap::process_group_() {
     if ((last_mask_ != mask) || !this->last_touched_) {
       this->last_touched_ = true;
       float publish_value = total_current_value / num_active_sensors;
-      ESP_LOGD(TAG, "%s - touched value: %f", this->name_.c_str(), publish_value);
+      ESP_LOGD(TAG, "%s - touched value: %.2f", this->name_.c_str(), publish_value);
       this->publish_state(publish_value);
       last_mask_ = mask;
     }


### PR DESCRIPTION
## Description:


**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with python changes (if applicable):** esphome/esphome#<esphome PR number goes here>
**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Checklist:

  - [ ] The code change is tested and works locally.
  - [ ] The code change follows the [standards](https://esphome.io/guides/contributing.html#contributing-to-esphome-core)

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
